### PR TITLE
fix(deprecations): phpunit ^8 raises warning on

### DIFF
--- a/src/Traits/SetterTrait.php
+++ b/src/Traits/SetterTrait.php
@@ -16,7 +16,8 @@ trait SetterTrait
         $setter = $this->getFunctionName('set', $this->toCamelCaseSetter($property), $options);
         $object = $this->init();
         $object->$setter($value);
-	$reflection = new \ReflectionClass($object);
+        
+        $reflection = new \ReflectionClass($object);
         $property = $reflection->getProperty($property);
         $property->setAccessible(true);
         $newValue = $property->getValue($object);

--- a/src/Traits/SetterTrait.php
+++ b/src/Traits/SetterTrait.php
@@ -16,7 +16,12 @@ trait SetterTrait
         $setter = $this->getFunctionName('set', $this->toCamelCaseSetter($property), $options);
         $object = $this->init();
         $object->$setter($value);
-        $this->assertAttributeSame($value, $property, $object);
+	$reflection = new \ReflectionClass($object);
+        $property = $reflection->getProperty($property);
+        $property->setAccessible(true);
+        $newValue = $property->getValue($object);
+
+        $this->assertSame($value, $newValue);
     }
 
     /**


### PR DESCRIPTION
To avoid getting a warning on a test with this message:
```
assertAttributeSame() is deprecated and will be removed in PHPUnit 9.
readAttribute() is deprecated and will be removed in PHPUnit 9.
getObjectAttribute() is deprecated and will be removed in PHPUnit 9.
```